### PR TITLE
fix: check if file path already has file prefix in it

### DIFF
--- a/ios/HybridMultipleImagePicker+Result.swift
+++ b/ios/HybridMultipleImagePicker+Result.swift
@@ -32,7 +32,7 @@ extension HybridMultipleImagePicker {
                             parentFolderName: nil,
                             creationDate: creationDate > 0 ? Double(creationDate) : nil,
                             crop: false,
-                            path: "file://\(url.absoluteString)",
+                            path: url.absoluteString.hasPrefix("file://") ? url.absoluteString : "file://\(url.absoluteString)",
                             type: type,
                             duration: asset.videoDuration,
                             thumbnail: thumbnail,


### PR DESCRIPTION
Fix duplicate "file://" prefix in image picker result path

The URL's absoluteString from both iOS Simulator and physical devices already contains the "file://" prefix. Previously, we were unconditionally adding another prefix, resulting in malformed paths like "file://file://...".

Added a check to only prepend "file://" if it's not already present in the path. While this scenario hasn't been observed in testing, this change makes the code more robust by handling edge cases where the prefix might be missing.