### PR TITLE
fix(android): replace getClass() with javaClassStatic()

### DIFF
--- a/nitrogen/generated/android/c++/JHybridMultipleImagePickerSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridMultipleImagePickerSpec.cpp
@@ -110,24 +110,24 @@ namespace margelo::nitro::multipleimagepicker {
   }
 
   size_t JHybridMultipleImagePickerSpec::getExternalMemorySize() noexcept {
-    static const auto method = _javaPart->getClass()->getMethod<jlong()>("getMemorySize");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jlong()>("getMemorySize");
     return method(_javaPart);
   }
 
   // Properties
-  
+
 
   // Methods
   void JHybridMultipleImagePickerSpec::openPicker(const NitroConfig& config, const std::function<void(const std::vector<PickerResult>& /* result */)>& resolved, const std::function<void(double /* reject */)>& rejected) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JNitroConfig> /* config */, jni::alias_ref<JFunc_void_std__vector_PickerResult_::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openPicker");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JNitroConfig> /* config */, jni::alias_ref<JFunc_void_std__vector_PickerResult_::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openPicker");
     method(_javaPart, JNitroConfig::fromCpp(config), JFunc_void_std__vector_PickerResult_::fromCpp(resolved), JFunc_void_double::fromCpp(rejected));
   }
   void JHybridMultipleImagePickerSpec::openCrop(const std::string& image, const NitroCropConfig& config, const std::function<void(const CropResult& /* result */)>& resolved, const std::function<void(double /* reject */)>& rejected) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JString> /* image */, jni::alias_ref<JNitroCropConfig> /* config */, jni::alias_ref<JFunc_void_CropResult::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openCrop");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* image */, jni::alias_ref<JNitroCropConfig> /* config */, jni::alias_ref<JFunc_void_CropResult::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openCrop");
     method(_javaPart, jni::make_jstring(image), JNitroCropConfig::fromCpp(config), JFunc_void_CropResult::fromCpp(resolved), JFunc_void_double::fromCpp(rejected));
   }
   void JHybridMultipleImagePickerSpec::openPreview(const std::vector<MediaPreview>& media, double index, const NitroPreviewConfig& config, const std::function<void(double /* index */)>& onLongPress) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<jni::JArrayClass<JMediaPreview>> /* media */, double /* index */, jni::alias_ref<JNitroPreviewConfig> /* config */, jni::alias_ref<JFunc_void_double::javaobject> /* onLongPress */)>("openPreview");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JArrayClass<JMediaPreview>> /* media */, double /* index */, jni::alias_ref<JNitroPreviewConfig> /* config */, jni::alias_ref<JFunc_void_double::javaobject> /* onLongPress */)>("openPreview");
     method(_javaPart, [&]() {
       size_t __size = media.size();
       jni::local_ref<jni::JArrayClass<JMediaPreview>> __array = jni::JArrayClass<JMediaPreview>::newArray(__size);
@@ -139,7 +139,7 @@ namespace margelo::nitro::multipleimagepicker {
     }(), index, JNitroPreviewConfig::fromCpp(config), JFunc_void_double::fromCpp(onLongPress));
   }
   void JHybridMultipleImagePickerSpec::openCamera(const NitroCameraConfig& config, const std::function<void(const CameraResult& /* result */)>& resolved, const std::function<void(double /* reject */)>& rejected) {
-    static const auto method = _javaPart->getClass()->getMethod<void(jni::alias_ref<JNitroCameraConfig> /* config */, jni::alias_ref<JFunc_void_CameraResult::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openCamera");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JNitroCameraConfig> /* config */, jni::alias_ref<JFunc_void_CameraResult::javaobject> /* resolved */, jni::alias_ref<JFunc_void_double::javaobject> /* rejected */)>("openCamera");
     method(_javaPart, JNitroCameraConfig::fromCpp(config), JFunc_void_CameraResult::fromCpp(resolved), JFunc_void_double::fromCpp(rejected));
   }
 


### PR DESCRIPTION
### Summary
This PR fixes a crash on Android 8+ caused by using `_javaPart->getClass()` 
to retrieve the Java class. 

The correct approach is to use `_javaPart->javaClassStatic()`, 
which avoids compatibility issues.

### Changes
- Replaced `_javaPart->getClass()` with `_javaPart->javaClassStatic()`
- Based on a similar fix from react-native-nitro: 
  https://github.com/mrousavy/nitro/pull/582

### Why?
On certain devices, `getClass()` is not allowed and leads to crashes 
when trying to access JNI methods. This update ensures better compatibility.

### Test Plan
- Tested on Android 8, 10, 13.
- Confirmed that `openPicker()` and other related functions work as expected.